### PR TITLE
Move ember-cli-htmlbars to devDependencies.

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "test:ember-compatibility": "ember try:each"
   },
   "dependencies": {
-    "ember-cli-htmlbars": "^4.3.1",
     "ember-cli-version-checker": "^2.1.0",
     "ember-factory-for-polyfill": "^1.3.1"
   },
@@ -45,6 +44,7 @@
     "ember-cli": "~3.18.0",
     "ember-cli-babel": "^7.19.0",
     "ember-cli-dependency-checker": "^3.2.0",
+    "ember-cli-htmlbars": "^4.3.1",
     "ember-cli-inject-live-reload": "^2.0.2",
     "ember-cli-shims": "^1.2.0",
     "ember-cli-sri": "^2.1.1",


### PR DESCRIPTION
There are no templates in this repo that are published, no need to keep it as a dep.